### PR TITLE
Normalizing Input Paths

### DIFF
--- a/ECMA2Yaml/ECMA2Yaml/CommandLineOptions.cs
+++ b/ECMA2Yaml/ECMA2Yaml/CommandLineOptions.cs
@@ -26,17 +26,17 @@ namespace ECMA2Yaml
         public CommandLineOptions()
         {
             _options = new OptionSet {
-                { "s|source=", "[Required] the folder path containing the ECMAXML files.", s => SourceFolder = s },
-                { "o|output=", "[Required] the output folder to put yml files.", o => OutputFolder = o },
-                { "m|metadata=", "the folder path containing the overwrite MD files for metadata.", s => MetadataFolder = s },
-                { "l|log=", "the log file path.", l => LogFilePath = l },
+                { "s|source=", "[Required] the folder path containing the ECMAXML files.", s => SourceFolder = s.NormalizePath() },
+                { "o|output=", "[Required] the output folder to put yml files.", o => OutputFolder = o.NormalizePath() },
+                { "m|metadata=", "the folder path containing the overwrite MD files for metadata.", s => MetadataFolder = s.NormalizePath() },
+                { "l|log=", "the log file path.", l => LogFilePath = l.NormalizePath() },
                 { "f|flatten", "to put all ymls in output root and not keep original folder structure.", f => Flatten = f != null },
-                { "p|pathUrlMapping={=>}", "map local xml path to the Github url.", (p, u) => { RepoRootPath = p;  GitBaseUrl = u; } },
+                { "p|pathUrlMapping={=>}", "map local xml path to the Github url.", (p, u) => { RepoRootPath = p.NormalizePath();  GitBaseUrl = u; } },
                 { "strict", "strict mode, means that any unresolved type reference will cause a warning",  s => StrictMode = s != null },
                 { "mapFolder", "folder mapping mode, maps assemblies in folder to json, used in .NET CI",  s => MapMode = s != null },
                 { "changeList=", "OPS change list file, ECMA2Yaml will translate xml path to yml path",  s => ChangeListFiles.Add(s)},
-                { "skipPublishFilePath=", "Pass a file to OPS to let it know which files should skip publish",  s => SkipPublishFilePath = s},
-                { "undocumentedApiReport=", "Save the Undocumented API validation result to Excel file",  s => UndocumentedApiReport = s},
+                { "skipPublishFilePath=", "Pass a file to OPS to let it know which files should skip publish",  s => SkipPublishFilePath = s.NormalizePath()},
+                { "undocumentedApiReport=", "Save the Undocumented API validation result to Excel file",  s => UndocumentedApiReport = s.NormalizePath()},
                 { "branch=", "current branch", s => CurrentBranch = s}
             };
         }

--- a/ECMA2Yaml/ECMAHelper/ECMAHelper.csproj
+++ b/ECMA2Yaml/ECMAHelper/ECMAHelper.csproj
@@ -60,6 +60,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Extensions\IdExtensions.cs" />
     <Compile Include="ECMALoader.docs.cs" />
     <Compile Include="ECMALoader.misc.cs" />

--- a/ECMA2Yaml/ECMAHelper/Extensions/StringExtensions.cs
+++ b/ECMA2Yaml/ECMAHelper/Extensions/StringExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.Linq;
+
+namespace ECMA2Yaml
+{
+    public static class StringExtensions
+    {
+        /// <summary>Defaults to <see cref="F:System.IO.Path.DirectorySeparatorChar"/>.
+        /// Should only be changed for unit testing purposes.</summary>
+        public static char DirectorySeparatorChar = System.IO.Path.DirectorySeparatorChar;
+
+        public static string NormalizePath(this string path)
+        {
+            if (path == null) return path;
+
+            char otherSepChar = '/';
+
+            if (DirectorySeparatorChar == '/')
+                otherSepChar = '\\';
+
+            if (path.Contains(otherSepChar))
+                path = path.Replace(otherSepChar, DirectorySeparatorChar);
+
+            return path;
+        }
+    }
+}

--- a/ECMA2Yaml/UnitTest/ExtensionTests.cs
+++ b/ECMA2Yaml/UnitTest/ExtensionTests.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ECMA2Yaml;
+
+namespace UnitTest
+{
+    [TestClass]
+    public class ExtensionTests
+    {
+        [TestCleanup]
+        public void Cleanup()
+        {
+            // reset the separator char back to default between tests
+            StringExtensions.DirectorySeparatorChar = System.IO.Path.DirectorySeparatorChar;
+        }
+
+        [TestMethod]
+        public void Test_UnixOnUnix()
+        {
+            StringExtensions.DirectorySeparatorChar = '/';
+            string path = "a/unix/path/on/unix";
+
+            // should be unchanged
+            Assert.AreEqual(path, path.NormalizePath());
+        }
+
+        [TestMethod]
+        public void Test_UnixOnWin()
+        {
+            StringExtensions.DirectorySeparatorChar = '\\';
+            string path = "a/unix/path/on/win";
+
+            // Separators should be flipped
+            Assert.AreEqual(@"a\unix\path\on\win", path.NormalizePath());
+        }
+
+        [TestMethod]
+        public void Test_WinOnWin()
+        {
+            StringExtensions.DirectorySeparatorChar = '\\';
+            string path = @"a\win\path\on\win";
+
+            // should be unchanged
+            Assert.AreEqual(path, path.NormalizePath());
+        }
+
+        [TestMethod]
+        public void Test_WinOnUnix()
+        {
+            StringExtensions.DirectorySeparatorChar = '/';
+            string path = @"a\win\path\on\unix";
+
+            // Separators should be flipped
+            Assert.AreEqual(@"a/win/path/on/unix", path.NormalizePath());
+        }
+
+        [TestMethod]
+        public void Test_MixedOnUnix()
+        {
+            StringExtensions.DirectorySeparatorChar = '/';
+            string path = @"a\mixed/path\on/unix";
+
+            // Separators should be consistent
+            Assert.AreEqual(@"a/mixed/path/on/unix", path.NormalizePath());
+        }
+
+        [TestMethod]
+        public void Test_MixedOnWin()
+        {
+            StringExtensions.DirectorySeparatorChar = '\\';
+            string path = @"a\mixed/path\on/win";
+
+            // Separators should be consistent
+            Assert.AreEqual(@"a\mixed\path\on\win", path.NormalizePath());
+        }
+
+        [TestMethod]
+        public void Test_NoNullReferenceException()
+        {
+            string aNullString = null;
+
+            // this should not throw an exception
+            Assert.IsNull(aNullString.NormalizePath());
+        }
+    }
+}

--- a/ECMA2Yaml/UnitTest/UnitTest.csproj
+++ b/ECMA2Yaml/UnitTest/UnitTest.csproj
@@ -63,6 +63,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ExtensionTests.cs" />
     <Compile Include="UnitTest1.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Closes #8

This change normalizes any input paths (please let me know if I got them all), so that if a developer erroneously inputs a path in the style of a platform that differs from the CI agent (this can often happen when the input variables come from CI, or a configuration file), all the IO APIs will still see the path in the form that it expects for that platform.

Usage samples in the unit tests.