### PR TITLE
now downgrading remark headers.

### DIFF
--- a/ECMA2Yaml/ECMAHelper/ECMALoader.docs.cs
+++ b/ECMA2Yaml/ECMAHelper/ECMALoader.docs.cs
@@ -140,10 +140,20 @@ namespace ECMA2Yaml
             return replaceTriggered ? string.Join(Environment.NewLine, lines) : remarksText;
         }
 
+        private static readonly string[] markdownHeaders = new string []
+        {
+            "#",
+            "##",
+            "###",
+            "####",
+            "#####",
+            "######"
+        };
+
         /// <summary>Modifies the array if a header of the given size is found</summary>
         private static void ReplaceTriggered(string[] lines, int headerCount, ref bool replaceTriggered)
         {
-            string headerPrefix = new string('#', headerCount);
+            string headerPrefix = markdownHeaders[headerCount-1];
             string newHeaderPrefix = null;
             bool inCodeFence = false;
             for (int i = 0; i < lines.Length; i++)
@@ -164,7 +174,7 @@ namespace ECMA2Yaml
                         continue;
 
                     if (newHeaderPrefix == null)
-                        newHeaderPrefix = new String('#', headerCount + 1);
+                        newHeaderPrefix = markdownHeaders[headerCount];
                     lines[i] = line.Replace(headerPrefix, newHeaderPrefix);
                     replaceTriggered = true;
                 }

--- a/ECMA2Yaml/UnitTest/MarkdownTests.cs
+++ b/ECMA2Yaml/UnitTest/MarkdownTests.cs
@@ -1,0 +1,51 @@
+﻿using ECMA2Yaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTest
+{
+    [TestClass]
+    public class MarkdownTests
+    {
+        [TestMethod]
+        public void DowngradeMarkdownHeader_H1() => AssertChange("# Thing", "## Thing");
+        [TestMethod]
+        public void DowngradeMarkdownHeader_H2() => AssertChange("## Thing", "### Thing");
+        [TestMethod]
+        public void DowngradeMarkdownHeader_H3() => AssertChange("### Thing", "#### Thing");
+        [TestMethod]
+        public void DowngradeMarkdownHeader_H4() => AssertChange("#### Thing", "##### Thing");
+        [TestMethod]
+        public void DowngradeMarkdownHeader_H5() => AssertChange("##### Thing", "###### Thing");
+        [TestMethod]
+        public void DowngradeMarkdownHeader_H6() => AssertChange("###### Thing", "###### Thing", shouldBeSame:true); // no change
+
+        // mixed headers
+
+        [TestMethod]
+        public void DowngradeMarkdownHeader_MixedHeaders() => AssertChange("# Thing\n## Thing\n### Thing\n#### Thing\n##### Thing\n###### Thing\n", $"## Thing{Environment.NewLine}### Thing{Environment.NewLine}#### Thing{Environment.NewLine}##### Thing{Environment.NewLine}###### Thing{Environment.NewLine}###### Thing{Environment.NewLine}");
+
+        // mixed line endings
+
+        [TestMethod]
+        public void DowngradeMarkdownHeader_MixedLineEnds() => AssertChange("# Thing\n## Thing\r\n### Thing\r\n\n", $"## Thing{Environment.NewLine}### Thing{Environment.NewLine}#### Thing{Environment.NewLine}{Environment.NewLine}");
+
+
+        // code that contains hashes
+        [TestMethod]
+        public void DowngradeMarkdownHeader_MixedHashContent() => AssertChange("# Thing\n```\nSome ##Code \n# A comment```\nafter code block", $"## Thing{Environment.NewLine}```{Environment.NewLine}Some ##Code {Environment.NewLine}# A comment```{Environment.NewLine}after code block");
+
+        private static void AssertChange(string startText, string expected, bool shouldBeSame = false)
+        {
+            var actual = ECMALoader.DowngradeMarkdownHeaders(startText);
+
+            if (!shouldBeSame)
+                Assert.AreNotEqual(actual, startText);
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/ECMA2Yaml/UnitTest/UnitTest.csproj
+++ b/ECMA2Yaml/UnitTest/UnitTest.csproj
@@ -64,6 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ExtensionTests.cs" />
+    <Compile Include="MarkdownTests.cs" />
     <Compile Include="UnitTest1.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Per requirements here: 
https://ceapex.visualstudio.com/Engineering/_queries/edit/63993

There is a dependent PR in the templates that should be merged in concert with this change:
https://ceapex.visualstudio.com/Engineering/_git/docs-ui/pullrequest/8378?_a=overview 

Please take a look at the unit tests to see examples of scenarios that this change handles. But a few assumptions and notes:

- I'm making a blanket assumption that all header levels should be downgraded, so the original work item only mentions h2 and h3, but this works on all headers.
- Will only transform h1 through h5 … this is because [html only supports up to h6](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements), so an h5 is converted to h6, but h6 would remain unchanged.
- Line endings will be normalized to the `Environment.NewLine` for whatever platform runs _Ecma2Yaml_ on CI … my assumption here is that the [git repo line endings configuration](https://help.github.com/articles/dealing-with-line-endings/) will be set accordingly, so _Ecma2Yaml_ should respect the platform.
- The code will **only** downgrade markdown headers that are at **the start** of a line. So that means that headers in a code section (indented by 4 spaces), or in a blockquote (line starts with a `>`), or in a ordered or unordered list **will not** be transformed. 
- Additionally, the code makes a special provision for content in a [GFM-style fenced code block](https://help.github.com/articles/creating-and-highlighting-code-blocks/#fenced-code-blocks) … this content will not be transformed either, which allows for documentation of markdown itself, or CLI scripts where comments start with `#`.

Please let me know if any of these assumptions are incorrect, or if anything should otherwise change. Thanks!