### PR TITLE
fix intellisense tools bugs for feature 187818

### DIFF
--- a/ECMA2Yaml/IntellisenseFileGen/Constants.cs
+++ b/ECMA2Yaml/IntellisenseFileGen/Constants.cs
@@ -35,5 +35,8 @@ namespace IntellisenseFileGen
         //this is a test page
         //```
         public static Regex TripleSytax_Pattern2 = new Regex("(```\\s*(.*?)\\s*```)", RegexOptions.Compiled);
+
+        // <summary>Creates an @Windows.AI.MachineLearning.ImageFeatureValue?text=ImageFeatureValue using the given video frame.</summary>
+        public static Regex Link_Pattern1 = new Regex("(@.*\\?text=(.*))", RegexOptions.Compiled);
     }
 }

--- a/ECMA2Yaml/IntellisenseFileGen/IntellisenseFileGenHelper.cs
+++ b/ECMA2Yaml/IntellisenseFileGen/IntellisenseFileGenHelper.cs
@@ -507,7 +507,17 @@ namespace IntellisenseFileGen
                 {
                     formatEles.ToList().ForEach(formatEle =>
                     {
-                        formatEle.ReplaceWith(formatEle.Value);
+                        string cdDataValue = formatEle.Value;
+                        var matches = RegexHelper.GetMatches_All_JustWantedOne(Constants.Link_Pattern1, cdDataValue);
+                        if (matches != null && matches.Length >= 2)
+                        {
+                            for (int i = 0; i < matches.Length; i += 2)
+                            {
+                                cdDataValue = cdDataValue.Replace(matches[i], matches[i + 1]);
+                            }
+                        }
+
+                        formatEle.ReplaceWith(System.Net.WebUtility.HtmlDecode(cdDataValue));
                     });
                 }
 

--- a/ECMA2Yaml/UnitTest/IntellisenseFileTests.cs
+++ b/ECMA2Yaml/UnitTest/IntellisenseFileTests.cs
@@ -135,6 +135,14 @@ Boolean isAvailable = scheduleObject.RawSchedule[2, 15, 3];
             PatternValidate(inText, expected, Constants.Link_Pattern);
         }
 
+        [DataTestMethod]
+        [DataRow("Creates an @Windows.AI.MachineLearning.ImageFeatureValue?text=ImageFeatureValue using the given video frame."
+                , "Creates an ImageFeatureValue using the given video frame.")]
+        public void Link_Pattern1_Test(string inText, string expected)
+        {
+            PatternValidate(inText, expected, Constants.Link_Pattern1);
+        }
+
         private static void SpecialProcessValidation(string inText, string expected)
         {
             XText text = new XText(inText);


### PR DESCRIPTION
implement following dev tasks:
Dev Task 187844: [UWP] [Intellisense] handle "-" (dash) became "&amp;mdash;" case 
Dev Task 187831: [UWP] [Intellisense] handle "&" became "amp;" case 
Dev Task 183768: [UWP] [Intellisense] @uid?text= syntax should be supported 
