### PR TITLE
Stop supporting MREF yaml generation

### DIFF
--- a/CI/devopsIntTest.ps1
+++ b/CI/devopsIntTest.ps1
@@ -14,6 +14,7 @@ else {
     Write-Host "Done testing intellisense..."
 }
 
+<#
 & "$repoRoot/ECMA2Yaml/ECMA2Yaml/bin/Release/ECMA2Yaml.exe" -s $repoRoot\test\xml -o $repoRoot\test\_yml_MREF_After -f --repoRoot $repoRoot\\ --repoBranch master --repoUrl https://github.com/docascode/ECMA2Yaml
 & "$repoRoot/ECMA2Yaml/DiffFiles/bin/Release/DiffFiles.exe" -o $repoRoot\test\yml_MREF -n $repoRoot\test\_yml_MREF_After -l $repoRoot\test --Path
 if ($LASTEXITCODE -ne 0)
@@ -23,6 +24,7 @@ if ($LASTEXITCODE -ne 0)
 else {
     Write-Host "Done testing MREF yml..."
 }
+#>
 
 & "$repoRoot/ECMA2Yaml/ECMA2Yaml/bin/Release/ECMA2Yaml.exe" -s $repoRoot\test\xml -o $repoRoot\test\_yml_SDP_After --SDP -f --repoRoot $repoRoot\\ --repoBranch master --repoUrl https://github.com/docascode/ECMA2Yaml
 & "$repoRoot/ECMA2Yaml/DiffFiles/bin/Release/DiffFiles.exe" -o $repoRoot\test\yml_SDP -n $repoRoot\test\_yml_SDP_After -l $repoRoot\test --Path

--- a/ECMA2Yaml/ECMA2Yaml/Program.cs
+++ b/ECMA2Yaml/ECMA2Yaml/Program.cs
@@ -31,6 +31,10 @@ namespace ECMA2Yaml
                     {
                         MapFolder(opt);
                     }
+                    else if (!opt.SDPMode && !opt.UWPMode)
+                    {
+                        OPSLogger.LogUserError(LogCode.ECMA2Yaml_SDP_MigrationNeeded, ".openpublishing.publish.config.json");
+                    }
                     else
                     {
                         LoadAndConvert(opt);

--- a/ECMA2Yaml/ECMAHelper/Logging/CommonLogMessages.json
+++ b/ECMA2Yaml/ECMAHelper/Logging/CommonLogMessages.json
@@ -5,7 +5,7 @@
       "log_codes": [
         {
           "log_code": "ECMA2Yaml_SDP_MigrationNeeded",
-          "message": "This repo/docset is not SDP-enabled. Please contact apidocs-team@service.microsoft.com to enable SDP on this repo",
+          "message": "This repo/docset is not SDP-enabled. Please contact apidocs-team@service.microsoft.com to enable SDP on this repo.",
           "document_url": ""
         },
         {

--- a/ECMA2Yaml/ECMAHelper/Logging/CommonLogMessages.json
+++ b/ECMA2Yaml/ECMAHelper/Logging/CommonLogMessages.json
@@ -4,6 +4,11 @@
       "category": "ECMA2Yaml",
       "log_codes": [
         {
+          "log_code": "ECMA2Yaml_SDP_MigrationNeeded",
+          "message": "This repo/docset is not SDP-enabled. Please contact apidocs-team@service.microsoft.com to enable SDP on this repo",
+          "document_url": ""
+        },
+        {
           "log_code": "ECMA2Yaml_Uid_Duplicated",
           "message": "Duplicate uid found: {0}",
           "document_url": ""

--- a/ECMA2Yaml/ECMAHelper/Logging/LogCode.cs
+++ b/ECMA2Yaml/ECMAHelper/Logging/LogCode.cs
@@ -13,7 +13,7 @@ namespace ECMA2Yaml
     public class LogCode : LogCodeBase
     {
     #region ECMA2Yaml
-		public static readonly LogCode ECMA2Yaml_SDP_MigrationNeeded = new LogCode("ECMA2Yaml_SDP_MigrationNeeded", "This repo/docset is not SDP-enabled. Please contact apidocs-team@service.microsoft.com to enable SDP on this repo");
+		public static readonly LogCode ECMA2Yaml_SDP_MigrationNeeded = new LogCode("ECMA2Yaml_SDP_MigrationNeeded", "This repo/docset is not SDP-enabled. Please contact apidocs-team@service.microsoft.com to enable SDP on this repo.");
 		public static readonly LogCode ECMA2Yaml_Uid_Duplicated = new LogCode("ECMA2Yaml_Uid_Duplicated", "Duplicate uid found: {0}");
 		public static readonly LogCode ECMA2Yaml_DocId_Duplicated = new LogCode("ECMA2Yaml_DocId_Duplicated", "Duplicated DocId found: {0}");
 		public static readonly LogCode ECMA2Yaml_MemberGroup_Duplicated = new LogCode("ECMA2Yaml_MemberGroup_Duplicated", "Found duplicated <MemberGroup> {0}");

--- a/ECMA2Yaml/ECMAHelper/Logging/LogCode.cs
+++ b/ECMA2Yaml/ECMAHelper/Logging/LogCode.cs
@@ -13,6 +13,7 @@ namespace ECMA2Yaml
     public class LogCode : LogCodeBase
     {
     #region ECMA2Yaml
+		public static readonly LogCode ECMA2Yaml_SDP_MigrationNeeded = new LogCode("ECMA2Yaml_SDP_MigrationNeeded", "This repo/docset is not SDP-enabled. Please contact apidocs-team@service.microsoft.com to enable SDP on this repo");
 		public static readonly LogCode ECMA2Yaml_Uid_Duplicated = new LogCode("ECMA2Yaml_Uid_Duplicated", "Duplicate uid found: {0}");
 		public static readonly LogCode ECMA2Yaml_DocId_Duplicated = new LogCode("ECMA2Yaml_DocId_Duplicated", "Duplicated DocId found: {0}");
 		public static readonly LogCode ECMA2Yaml_MemberGroup_Duplicated = new LogCode("ECMA2Yaml_MemberGroup_Duplicated", "Found duplicated <MemberGroup> {0}");


### PR DESCRIPTION
This change will only affect .NET repos. We continue to support mref yamls for UWP repos for now.