### PR TITLE
Adding monikerized return type

### DIFF
--- a/ECMA2Yaml/ECMAHelper/ECMALoader.cs
+++ b/ECMA2Yaml/ECMAHelper/ECMALoader.cs
@@ -233,10 +233,7 @@ namespace ECMA2Yaml
             var rvalElement = tRoot.Element("ReturnValue");
             if (rvalElement != null)
             {
-                t.ReturnValueType = new Parameter()
-                {
-                    Type = rvalElement.Element("ReturnType")?.Value
-                };
+                t.ReturnValueType = MonikerizeReturnValue(rvalElement);
             }
 
             //BaseTypeName
@@ -424,22 +421,10 @@ namespace ECMA2Yaml
                 m.Attributes = attrs.Elements("Attribute").Select(a => LoadAttribute(a)).ToList();
             }
 
-            var returnTypeStr = mElement.Element("ReturnValue")?.Element("ReturnType")?.Value;
-            if (returnTypeStr != null)
-            {
-                var returnType = new Parameter()
-                {
-                    Type = returnTypeStr,
-                    OriginalTypeString = returnTypeStr
-                };
-                if (returnType.Type.EndsWith("&"))
-                {
-                    returnType.Type = returnType.Type.TrimEnd('&');
-                    returnType.RefType = "ref";
-                }
-                returnType.Type = returnType.Type.Replace('+', '.');
-                m.ReturnValueType = returnType;
-            }
+            // Load monikerized return type data
+            var returnValueElement = mElement.Element("ReturnValue");
+
+            m.ReturnValueType = MonikerizeReturnValue(returnValueElement);
 
             var implements = mElement.Element("Implements");
             if (implements != null)
@@ -453,6 +438,31 @@ namespace ECMA2Yaml
             LoadMetadata(m, mElement);
 
             return m;
+        }
+
+        public static ReturnValue MonikerizeReturnValue(XElement returnValueElement)
+        {
+            var returnTypes = returnValueElement?.Elements("ReturnType").Select(r => new { ReturnType = r.Value, Monikers = ECMALoader.LoadFrameworkAlternate(r) });
+            if (returnTypes == null || !returnTypes.Any()) return null;
+
+            Func<VersionedReturnType, VersionedReturnType> toParam = s =>
+            {
+                var returnType = s;
+                if (returnType.Value.EndsWith("&"))
+                {
+                    returnType.Value = returnType.Value.TrimEnd('&');
+                    returnType.RefType = "ref";
+                }
+                returnType.Value = returnType.Value.Replace('+', '.');
+                return returnType;
+            };
+            var returns = returnTypes.Select(r => new VersionedReturnType
+            {
+                Value = r.ReturnType,
+                Monikers = r.Monikers
+            }).Select(toParam);
+
+            return new ReturnValue() { VersionedTypes = returns.ToArray() };
         }
 
         private Member LoadMemberGroup(Models.Type t, XElement mElement)

--- a/ECMA2Yaml/ECMAHelper/Models/Member.cs
+++ b/ECMA2Yaml/ECMAHelper/Models/Member.cs
@@ -54,7 +54,9 @@ namespace ECMA2Yaml.Models
             {
                 if (Name == "op_Explicit" || Name == "op_Implicit")
                 {
-                    paramPart = string.Format("({0} to {1})", Parameters.First().Type.ToDisplayName(), ReturnValueType.Type.ToDisplayName());
+                    var rtype = ReturnValueType.VersionedTypes.First().Value.ToDisplayName();
+
+                    paramPart = string.Format("({0} to {1})", Parameters.First().Type.ToDisplayName(), rtype);
                 }
                 else if (IsIndexer)
                 {
@@ -106,9 +108,12 @@ namespace ECMA2Yaml.Models
                 {
                     var typeParamsOnType = Parent.TypeParameters?.Select(tp => tp.Name).ToList();
                     var typeParamsOnMember = TypeParameters?.Select(tp => tp.Name).ToList();
+
+                    var rtype = ReturnValueType.VersionedTypes.First().Value;
+
                     Id += string.Format("({0})~{1}",
                         Parameters.First().Type.ToSpecId(typeParamsOnType, typeParamsOnMember),
-                        ReturnValueType.Type.ToSpecId(typeParamsOnType, typeParamsOnMember));
+                        rtype.ToSpecId(typeParamsOnType, typeParamsOnMember));
                 }
                 //spec is wrong, no need to treat indexer specially, so comment this part out
                 //else if (MemberType == MemberType.Property && Signatures.ContainsKey("C#") && Signatures["C#"].Contains("["))

--- a/ECMA2Yaml/ECMAHelper/Models/Parameter.cs
+++ b/ECMA2Yaml/ECMAHelper/Models/Parameter.cs
@@ -65,10 +65,15 @@ namespace ECMA2Yaml.Models
         }
     }
 
-    public class Parameter : ParameterBase
+    public class Parameter : ParameterBase, IEquatable<Parameter>
     {
         public string Type { get; set; }
         public string OriginalTypeString { get; set; }
+
+        public bool Equals(Parameter other)
+        {
+            return other != null && other.Type == this.Type && other.OriginalTypeString == this.OriginalTypeString;        
+        }
 
         public override void LoadFromXElement(XElement p)
         {

--- a/ECMA2Yaml/ECMAHelper/Models/ReflectionItem.cs
+++ b/ECMA2Yaml/ECMAHelper/Models/ReflectionItem.cs
@@ -83,7 +83,7 @@ namespace ECMA2Yaml.Models
         }
         public List<TypeParameter> TypeParameters { get; set; }
         public List<Parameter> Parameters { get; set; }
-        public Parameter ReturnValueType { get; set; }
+        public ReturnValue ReturnValueType { get; set; }
         public VersionedSignatures Signatures { get; set; }
         public List<ECMAAttribute> Attributes { get; set; }
         public ReflectionItem Parent { get; set; }

--- a/ECMA2Yaml/ECMAHelper/Models/ReturnValue.cs
+++ b/ECMA2Yaml/ECMAHelper/Models/ReturnValue.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using YamlDotNet.Serialization;
+
+namespace ECMA2Yaml.Models
+{
+    public class ReturnValue
+    {
+        [JsonProperty("type")]
+        [YamlMember(Alias = "type")]
+        public IEnumerable<VersionedReturnType> VersionedTypes {get;set;}
+
+
+        [JsonProperty("description")]
+        [YamlMember(Alias = "description")]
+        public string Description { get; set; }
+    }
+}

--- a/ECMA2Yaml/ECMAHelper/Models/SDP/DelegateSDPModel.cs
+++ b/ECMA2Yaml/ECMAHelper/Models/SDP/DelegateSDPModel.cs
@@ -20,6 +20,10 @@ namespace ECMA2Yaml.Models.SDP
         [YamlMember(Alias = "returns")]
         public TypeReference Returns { get; set; }
 
+        [JsonProperty("returnsWithMoniker")]
+        [YamlMember(Alias = "returnsWithMoniker")]
+        public ReturnValue ReturnsWithMoniker { get; set; }
+
         [JsonProperty("parameters")]
         [YamlMember(Alias = "parameters")]
         public IEnumerable<ParameterReference> Parameters { get; set; }

--- a/ECMA2Yaml/ECMAHelper/Models/SDP/MemberSDPModel.cs
+++ b/ECMA2Yaml/ECMAHelper/Models/SDP/MemberSDPModel.cs
@@ -20,6 +20,10 @@ namespace ECMA2Yaml.Models.SDP
         [YamlMember(Alias = "returns")]
         public TypeReference Returns { get; set; }
 
+        [JsonProperty("returnsWithMoniker")]
+        [YamlMember(Alias = "returnsWithMoniker")]
+        public ReturnValue ReturnsWithMoniker { get; set; }
+
         [JsonProperty("parameters")]
         [YamlMember(Alias = "parameters")]
         public IEnumerable<ParameterReference> Parameters { get; set; }

--- a/ECMA2Yaml/ECMAHelper/Models/VersionedValue.cs
+++ b/ECMA2Yaml/ECMAHelper/Models/VersionedValue.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using ECMA2Yaml.Models.SDP;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,6 +16,25 @@ namespace ECMA2Yaml.Models
         public VersionedString(HashSet<string> monikers, string value) : base(monikers, value)
         {
         }
+    }
+
+    public class VersionedReturnType : VersionedString
+    {
+        [JsonProperty("refType")]
+        [YamlMember(Alias = "refType")]
+        public string RefType { get; set; }
+        public VersionedReturnType() { }
+        public VersionedReturnType(HashSet<string> monikers, string value, string reftype) : base(monikers, value)
+        {
+            RefType = reftype;
+        }
+    }
+
+    public class VersionedTypeReference : VersionedValue<TypeReference>
+    {
+        public VersionedTypeReference() { }
+
+        public VersionedTypeReference(HashSet<string> monikers, TypeReference typeRef) : base(monikers, typeRef) { }
     }
 
     public class VersionedValue<T>

--- a/ECMA2Yaml/ECMAHelper/YamlConverters/SDPYamlConverter.Delegate.cs
+++ b/ECMA2Yaml/ECMAHelper/YamlConverters/SDPYamlConverter.Delegate.cs
@@ -17,14 +17,40 @@ namespace ECMA2Yaml
             sdpDelegate.TypeParameters = ConvertTypeParameters(t);
             sdpDelegate.Inheritances = t.InheritanceChains?.LastOrDefault().Values.Select(uid => UidToTypeMDString(uid, _store)).ToList();
 
-            if (t.ReturnValueType != null
-                && !string.IsNullOrEmpty(t.ReturnValueType.Type)
-                && t.ReturnValueType.Type != "System.Void"
-                && t.ItemType != ItemType.Event)
+            if (t.ReturnValueType != null && t.ItemType != ItemType.Event)
             {
-                sdpDelegate.Returns = ConvertParameter<TypeReference>(t.ReturnValueType);
-            }
+                var returns = t.ReturnValueType;
 
+                if (returns.VersionedTypes.Count() == 1)
+                {
+                    var oneReturn = returns.VersionedTypes.First();
+                    if (oneReturn != null
+                    && !string.IsNullOrWhiteSpace(oneReturn.Value)
+                    && oneReturn.Value != "System.Void")
+                    {
+                        sdpDelegate.Returns = new TypeReference()
+                        {
+                            Type = SDPYamlConverter.TypeStringToTypeMDString(oneReturn.Value, _store),
+                            
+                            Description = returns.Description
+                        };
+                    }
+                }
+                else
+                {
+                    var r = returns.VersionedTypes
+                        .Where(v => !string.IsNullOrWhiteSpace(v.Value) && v.Value != "System.Void");
+                    if (r.Any())
+                    {
+                        foreach (var vt in returns.VersionedTypes)
+                        {
+                            vt.Value = SDPYamlConverter.TypeStringToTypeMDString(vt.Value, _store);
+                        }
+                        sdpDelegate.ReturnsWithMoniker = returns;
+                    }
+                }
+            }
+            
             sdpDelegate.Parameters = t.Parameters?.Select(p => ConvertNamedParameter(p, t.TypeParameters))
                 .ToList().NullIfEmpty();
 

--- a/ECMA2Yaml/UndocumentedApi/Validator.cs
+++ b/ECMA2Yaml/UndocumentedApi/Validator.cs
@@ -33,13 +33,12 @@ namespace ECMA2Yaml.UndocumentedApi
 
         public static ValidationResult ValidateReturnValue(ReflectionItem item)
         {
-            if (item.ReturnValueType == null
-                || string.IsNullOrEmpty(item.ReturnValueType.Type)
-                || item.ReturnValueType.Type == "System.Void"
-                || item.ItemType == ItemType.Event)
-            {
+            if (item.ReturnValueType == null 
+                || item.ItemType == ItemType.Event
+                || item.ReturnValueType.VersionedTypes.Any(r => 
+                        string.IsNullOrWhiteSpace(r.Value)
+                        || r.Value == "System.Void"))
                 return ValidationResult.NA;
-            }
 
             var result = ValidateSimpleString(item.Docs.Returns, ReturnsLengthRequirement);
 


### PR DESCRIPTION
Re-opening this from this previous PR from a fork:
https://github.com/docascode/ECMA2Yaml/pull/110

@TianqiZhang, I've changed the data structure so that description doesn't have to be duplicated amongst all individual values. Additionally, return type now has its own data model across the process ... and it is backwards compatible with the "legacy" single return value pipelines.