### PR TITLE
handle inheritedMember and member moniker overlap

### DIFF
--- a/ECMA2Yaml/ECMAHelper/Models/ECMAStore.cs
+++ b/ECMA2Yaml/ECMAHelper/Models/ECMAStore.cs
@@ -953,10 +953,13 @@ namespace ECMA2Yaml.Models
                             {
                                 // could be defined in one moniker, but inherited in another moniker
                                 // so we should check both the id and moniker
-                                if (inheritedMembersById.TryGetValue(m.Id, out var inheritedMember)
-                                    && m.Monikers.Overlaps(inheritedMember.Monikers))
+                                if (inheritedMembersById.TryGetValue(m.Id, out var inheritedMember))
                                 {
-                                    inheritedMembersById.Remove(m.Id);
+                                    inheritedMember.Monikers.RemoveWhere(m.Monikers.Contains);
+                                    if(inheritedMember.Monikers.Count == 0)
+                                    {
+                                        inheritedMembersById.Remove(m.Id);
+                                    }
                                 }
                             }
                         }

--- a/ECMA2Yaml/ECMAHelper/Models/ECMAStore.cs
+++ b/ECMA2Yaml/ECMAHelper/Models/ECMAStore.cs
@@ -955,7 +955,8 @@ namespace ECMA2Yaml.Models
                                 // so we should check both the id and moniker
                                 if (inheritedMembersById.TryGetValue(m.Id, out var inheritedMember))
                                 {
-                                    inheritedMember.Monikers.RemoveWhere(m.Monikers.Contains);
+                                    // Create another HashSet since all the inheritedMembersById share the same "Monikers" object
+                                    inheritedMember.Monikers = inheritedMember.Monikers.Except(m.Monikers).ToHashSet();
                                     if(inheritedMember.Monikers.Count == 0)
                                     {
                                         inheritedMembersById.Remove(m.Id);


### PR DESCRIPTION
Sample update with this fix:

![image](https://user-images.githubusercontent.com/8327019/82412117-9e0aa300-9aa5-11ea-8876-4c808b7be312.png)
