### PR TITLE
Update MSDNUrlPatch tool according to customer require

### DIFF
--- a/ECMA2Yaml/UnitTest/MSDNUrlPatchTests.cs
+++ b/ECMA2Yaml/UnitTest/MSDNUrlPatchTests.cs
@@ -12,18 +12,18 @@ namespace UnitTest
     public class MSDNUrlPatchTests
     {
         [DataTestMethod]
-        //[DataRow(@"https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&view1=netcore-3.1"
-        //            , "https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&view1=netcore-3.1")]
-        //[DataRow(@"https://docs.microsoft.com/en-us/previous-versions/ms180941(v=vs.90)?redirectedfrom=MSDN"
-        //            , "https://docs.microsoft.com/en-us/previous-versions/ms180941(v=vs.90)")]
-        //[DataRow("https://docs.microsoft.com/en-us/dotnet/api/system.object?redirectedfrom=MSDN&view1=netcore-3.1"
-        //            , "https://docs.microsoft.com/en-us/dotnet/api/system.object?view1=netcore-3.1")]
-        //[DataRow("https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&redirectedfrom=MSDN&view1=netcore-3.1"
-        //            , "https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&view1=netcore-3.1")]
-        //[DataRow("https://docs.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015&redirectedfrom=MSDN"
-        //            , "https://docs.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015")]
-        //[DataRow("https://docs1.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015&redirectedfrom=MSDN"
-        //            , "https://docs1.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015")]
+        [DataRow(@"https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&view1=netcore-3.1"
+                    , "https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&view1=netcore-3.1")]
+        [DataRow(@"https://docs.microsoft.com/en-us/previous-versions/ms180941(v=vs.90)?redirectedfrom=MSDN"
+                    , "https://docs.microsoft.com/en-us/previous-versions/ms180941(v=vs.90)")]
+        [DataRow("https://docs.microsoft.com/en-us/dotnet/api/system.object?redirectedfrom=MSDN&view1=netcore-3.1"
+                    , "https://docs.microsoft.com/en-us/dotnet/api/system.object?view1=netcore-3.1")]
+        [DataRow("https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&redirectedfrom=MSDN&view1=netcore-3.1"
+                    , "https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&view1=netcore-3.1")]
+        [DataRow("https://docs.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015&redirectedfrom=MSDN"
+                    , "https://docs.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015")]
+        [DataRow("https://docs1.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015&redirectedfrom=MSDN"
+                    , "https://docs1.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015")]
         [DataRow(@"https://docs.microsoft.com/en-us/windows/win32/seccng/cng-token-binding-functions\(v=vs.85\).aspx"
                     , "https://docs.microsoft.com/en-us/windows/win32/seccng/cng-token-binding-functions")]
         public void RemoveRedirectFromPart_Test(string inText, string expected)

--- a/ECMA2Yaml/UnitTest/MSDNUrlPatchTests.cs
+++ b/ECMA2Yaml/UnitTest/MSDNUrlPatchTests.cs
@@ -12,18 +12,20 @@ namespace UnitTest
     public class MSDNUrlPatchTests
     {
         [DataTestMethod]
-        [DataRow(@"https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&view1=netcore-3.1"
-                    , "https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&view1=netcore-3.1")]
-        [DataRow(@"https://docs.microsoft.com/en-us/previous-versions/ms180941(v=vs.90)?redirectedfrom=MSDN"
-                    , "https://docs.microsoft.com/en-us/previous-versions/ms180941(v=vs.90)")]
-        [DataRow("https://docs.microsoft.com/en-us/dotnet/api/system.object?redirectedfrom=MSDN&view1=netcore-3.1"
-                    , "https://docs.microsoft.com/en-us/dotnet/api/system.object?view1=netcore-3.1")]
-        [DataRow("https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&redirectedfrom=MSDN&view1=netcore-3.1"
-                    , "https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&view1=netcore-3.1")]
-        [DataRow("https://docs.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015&redirectedfrom=MSDN"
-                    , "https://docs.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015")]
-        [DataRow("https://docs1.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015&redirectedfrom=MSDN"
-                    , "https://docs1.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015")]
+        //[DataRow(@"https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&view1=netcore-3.1"
+        //            , "https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&view1=netcore-3.1")]
+        //[DataRow(@"https://docs.microsoft.com/en-us/previous-versions/ms180941(v=vs.90)?redirectedfrom=MSDN"
+        //            , "https://docs.microsoft.com/en-us/previous-versions/ms180941(v=vs.90)")]
+        //[DataRow("https://docs.microsoft.com/en-us/dotnet/api/system.object?redirectedfrom=MSDN&view1=netcore-3.1"
+        //            , "https://docs.microsoft.com/en-us/dotnet/api/system.object?view1=netcore-3.1")]
+        //[DataRow("https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&redirectedfrom=MSDN&view1=netcore-3.1"
+        //            , "https://docs.microsoft.com/en-us/dotnet/api/system.object?test=vb&view1=netcore-3.1")]
+        //[DataRow("https://docs.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015&redirectedfrom=MSDN"
+        //            , "https://docs.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015")]
+        //[DataRow("https://docs1.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015&redirectedfrom=MSDN"
+        //            , "https://docs1.microsoft.com/en-us/visualstudio/msbuild/aspnetcompiler-task?view1=vs-2015")]
+        [DataRow(@"https://docs.microsoft.com/en-us/windows/win32/seccng/cng-token-binding-functions\(v=vs.85\).aspx"
+                    , "https://docs.microsoft.com/en-us/windows/win32/seccng/cng-token-binding-functions")]
         public void RemoveRedirectFromPart_Test(string inText, string expected)
         {
             CommandLineOptions option = new CommandLineOptions();


### PR DESCRIPTION
Update MSDNUrlPatch tool according to customer require

		○ Don't replace msdn links with different msdn links (the F# content still hasn't migrated)
		○ There are a couple of links that have a version extension that is being kept when the link is updated to docs, The version should be removed. The extension looks like this for example: \(v=vs.85\).aspx