### PR TITLE
fix bug 296479

### DIFF
--- a/ECMA2Yaml/IntellisenseFileGen/Constants.cs
+++ b/ECMA2Yaml/IntellisenseFileGen/Constants.cs
@@ -37,6 +37,6 @@ namespace IntellisenseFileGen
         public static Regex TripleSytax_Pattern2 = new Regex("(```\\s*(.*?)\\s*```)", RegexOptions.Compiled);
 
         // <summary>Creates an @Windows.AI.MachineLearning.ImageFeatureValue?text=ImageFeatureValue using the given video frame.</summary>
-        public static Regex Link_Pattern1 = new Regex("(@.*?\\?text=(\\w*))", RegexOptions.Compiled);
+        public static Regex Link_Pattern1 = new Regex("(@.*?\\?text=(\\w*)\"?)", RegexOptions.Compiled);
     }
 }

--- a/ECMA2Yaml/UnitTest/IntellisenseFileTests.cs
+++ b/ECMA2Yaml/UnitTest/IntellisenseFileTests.cs
@@ -138,6 +138,8 @@ Boolean isAvailable = scheduleObject.RawSchedule[2, 15, 3];
         }
 
         [DataTestMethod]
+        [DataRow("Creates an @\"Windows.AI.MachineLearning.ImageFeatureValue?text=ImageFeatureValue\" using the given video frame."
+                , "Creates an ImageFeatureValue using the given video frame.")]
         [DataRow("Creates an @Windows.AI.MachineLearning.ImageFeatureValue?text=ImageFeatureValue using the given video frame."
                 , "Creates an ImageFeatureValue using the given video frame.")]
         [DataRow(@"Creates an instance of @Windows.UI.Composition.Interactions.InteractionTracker?text=InteractionTracker.


### PR DESCRIPTION
Fix Bug 296479: [.NET] [Intellisense] Extra double quote '"' left behind after removed cref link