### PR TITLE
Task 438266 - [.NET] Support language selection for implements

### DIFF
--- a/ECMA2Yaml/ECMAHelper/Models/VersionedValue.cs
+++ b/ECMA2Yaml/ECMAHelper/Models/VersionedValue.cs
@@ -26,9 +26,9 @@ namespace ECMA2Yaml.Models
     {
         public VersionedString() { }
 
-        [JsonProperty("perLanguage")]
-        [YamlMember(Alias = "perLanguage")]
-        public List<PerLanguageString> PerLanguage { get; set; }
+        [JsonProperty("valuePerLanguage")]
+        [YamlMember(Alias = "valuePerLanguage")]
+        public List<PerLanguageString> valuePerLanguage { get; set; }
 
         public VersionedString(HashSet<string> monikers, string value) : base(monikers, value)
         {

--- a/ECMA2Yaml/ECMAHelper/YamlConverters/SDPYamlConverter.Member.cs
+++ b/ECMA2Yaml/ECMAHelper/YamlConverters/SDPYamlConverter.Member.cs
@@ -12,9 +12,13 @@ namespace ECMA2Yaml
 
             sdpMember.TypeParameters = ConvertTypeParameters(m);
             sdpMember.ThreadSafety = ConvertThreadSafety(m);
-            sdpMember.ImplementsWithMoniker = m.Implements?.Select(impl => new VersionedString(impl.Monikers, DocIdToTypeMDString(impl.Value, _store)))
-                .Where(impl => impl.Value != null)
-                .ToList().NullIfEmpty();
+            sdpMember.ImplementsWithMoniker = m.Implements?.Select(impl => new VersionedString()
+            {
+                Monikers = impl.Monikers,
+                Value = DocIdToTypeMDString(impl.Value, _store),
+                valuePerLanguage = TypeStringToMDWithTypeMapping(impl.Value, m.Signatures?.DevLangs, nullIfTheSame: true)
+            });
+
             sdpMember.ImplementsMonikers = ConverterHelper.ConsolidateVersionedValues(sdpMember.ImplementsWithMoniker, m.Monikers);
 
             var knowTypeParams = m.Parent.TypeParameters.ConcatList(m.TypeParameters);

--- a/ECMA2Yaml/ECMAHelper/YamlConverters/SDPYamlConverter.Type.cs
+++ b/ECMA2Yaml/ECMAHelper/YamlConverters/SDPYamlConverter.Type.cs
@@ -22,7 +22,12 @@ namespace ECMA2Yaml
             t.Monikers);
             sdpType.DerivedClassesWithMoniker = MonikerizeDerivedClasses(t);
             sdpType.ImplementsWithMoniker = t.Interfaces?.Where(i => i != null && i.Value != null)
-                .Select(i => new VersionedString(i.Monikers, TypeStringToTypeMDString(i.Value, _store)))
+                 .Select(i => new VersionedString()
+                  {
+                     Monikers = i.Monikers,
+                     Value = TypeStringToTypeMDString(i.Value, _store),
+                     valuePerLanguage = TypeStringToMDWithTypeMapping(i.Value, t.Signatures?.DevLangs,nullIfTheSame: true)
+                  })
                 .ToList()
                 .NullIfEmpty();
             sdpType.ImplementsMonikers = ConverterHelper.ConsolidateVersionedValues(sdpType.ImplementsWithMoniker, t.Monikers);

--- a/ECMA2Yaml/ECMAHelper/YamlConverters/SDPYamlConverter.cs
+++ b/ECMA2Yaml/ECMAHelper/YamlConverters/SDPYamlConverter.cs
@@ -105,7 +105,7 @@ namespace ECMA2Yaml
                 { 
                     Value = att.TypeFullName,
                     Monikers = att.Monikers?.ToHashSet(),
-                    PerLanguage = TypeStringToMDWithTypeMapping(att.TypeFullName, item.Signatures?.DevLangs, nullIfTheSame: true) 
+                    valuePerLanguage = TypeStringToMDWithTypeMapping(att.TypeFullName, item.Signatures?.DevLangs, nullIfTheSame: true, isToMDString: false) 
                 })
                 .DistinctVersionedString()
                 .ToList().NullIfEmpty();
@@ -317,8 +317,8 @@ namespace ECMA2Yaml
         private List<PerLanguageString> TypeStringToMDWithTypeMapping(
             string typeString,
             HashSet<string> totalLangs = null,
-            bool nullIfTheSame = false)
-        {
+            bool nullIfTheSame = false, bool isToMDString = true)
+        { 
             if (_store.TypeMappingStore != null)
             {
                 var typePerLanguage = _store.TypeMappingStore.TranslateTypeString(typeString, totalLangs ?? _store.TotalDevLangs);
@@ -328,7 +328,11 @@ namespace ECMA2Yaml
                     {
                         return null;
                     }
-                    typePerLanguage.ForEach(typePerLang => typePerLang.Value = TypeStringToTypeMDString(typePerLang.Value, _store));
+
+                    if (isToMDString)
+                    {
+                        typePerLanguage.ForEach(typePerLang => typePerLang.Value = TypeStringToTypeMDString(typePerLang.Value, _store));
+                    }
                     return typePerLanguage;
                 }
             }


### PR DESCRIPTION
1.Task#438266:[.NET] Support language selection for implements
2.Rename perlanguage of attributesWithMoniker, the same as valuePerlanguage of returnsWithMoniker and inheritancesWithMoniker.
3. valuePerlanguage of attributesWithMoniker should not be converted to MDString.